### PR TITLE
Add optional seed to shuffle

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,6 +282,13 @@ Shuffled array: {{#shuffle array}}{{this}} {{/shuffle}}
 Shuffled array: Vulcan Raven Psycho Mantis Revolver Ocelot Liquid Snake Sniper Wolf Decoy Octopus
 ```
 
+Optionally a seed can be passed so that the returned array is reproducible. Please use a seed other than 0.
+
+```handlebars
+Shuffled array: {{#shuffle array seed=1}}{{this}} {{/shuffle}}
+```
+
+
 ### Reverse
 
 Loop through an array in reverse order.

--- a/lib/helpers/shuffle.js
+++ b/lib/helpers/shuffle.js
@@ -1,8 +1,15 @@
+// From http://stackoverflow.com/a/19303725/2032154
+var seededRandom = function(seed) {
+	return function random() {
+		var x = Math.sin(seed++) * 10000;
+		return x - Math.floor(x);
+	}
+}
 // Simple shuffling method based off of http://bost.ocks.org/mike/shuffle/
-var shuffle = function( array ){
+var shuffle = function( array, prng ){
 	var i = array.length, j, swap;
 	while( i ){
-		j = Math.floor( Math.random() * i-- );
+		j = Math.floor( prng() * i-- );
 		swap = array[i];
 		array[i] = array[j];
 		array[j] = swap;
@@ -11,7 +18,12 @@ var shuffle = function( array ){
 };
 
 module.exports = function( collection, options ){
-	var shuffled = shuffle( collection );
+	var prng = Math.random;
+	if(options.hash.seed !== undefined) {
+		prng = seededRandom(options.hash.seed);
+	}
+
+	var shuffled = shuffle( collection, prng );
 	var result = '';
 	for( var i = 0; i < shuffled.length; i++ ){
 		result += options.fn( shuffled[i] );

--- a/test/index.js
+++ b/test/index.js
@@ -176,14 +176,24 @@ test( 'where', function( t ){
 });
 
 test( 'shuffle', function( t ){
-	t.plan(1);
+	t.plan(2);
 	var array = ['Psycho Mantis','Sniper Wolf', 'Vulcan Raven', 'Decoy Octopus', 'Revolver Ocelot', 'Liquid Snake'];
-	var tpl = Handlebars.compile('{{#shuffle this}}{{this}},{{/shuffle}}');
-	var result = tpl( array );
-	var result_array = result.substring( 0, result.length - 1 ).split(',');
+	function shuffle(array){
+		var tpl = Handlebars.compile('{{#shuffle this}}{{this}},{{/shuffle}}');
+		var result = tpl( array );
+		return result.substring( 0, result.length - 1 ).split(',');
+	}
+	var result_array = shuffle(array);
 	result_array.sort();
 	array.sort();
 	t.equal( result_array.join(), array.join(), 'shuffled collection contains same elements as original collection' );
+	var firstElementDifferent = false;
+	for (var i=0; i<100; i++) {
+		var firstElement = shuffle(array)[0];
+		array.sort();
+		firstElementDifferent = firstElementDifferent || firstElement !== array[0];
+	}
+	t.true( firstElementDifferent, 'shuffled collection should be eventually different than the original' );
 });
 
 test( 'reverse', function( t ){

--- a/test/index.js
+++ b/test/index.js
@@ -230,8 +230,8 @@ test( 'formatDate', function( t ){
 		'2013-09-30T15:00:00.340Z',
 		'2013/09/30 15:00:00 +0000',
 		'Mon Sep 30 2013 15:00:00 GMT-0700 (PDT)',
-		1380578400000,
-		'1380578400000'
+		1380578400000 + new Date().getTimezoneOffset() * MINUTE,
+		String(1380578400000 + new Date().getTimezoneOffset() * MINUTE)
 	];
 	var tpl = Handlebars.compile('{{formatDate this "%A, %B %o %Y"}}');
 	t.equal( tpl( dates[0] ), 'Monday, September 30th 2013', 'date successfully formatted' );

--- a/test/index.js
+++ b/test/index.js
@@ -176,7 +176,7 @@ test( 'where', function( t ){
 });
 
 test( 'shuffle', function( t ){
-	t.plan(2);
+	t.plan(4);
 	var array = ['Psycho Mantis','Sniper Wolf', 'Vulcan Raven', 'Decoy Octopus', 'Revolver Ocelot', 'Liquid Snake'];
 	function shuffle(array){
 		var tpl = Handlebars.compile('{{#shuffle this}}{{this}},{{/shuffle}}');
@@ -194,6 +194,29 @@ test( 'shuffle', function( t ){
 		firstElementDifferent = firstElementDifferent || firstElement !== array[0];
 	}
 	t.true( firstElementDifferent, 'shuffled collection should be eventually different than the original' );
+
+	var shuffledFirst = shuffle(array)[0];
+	firstElementDifferent = false;
+	for (var i=0; i<100; i++) {
+		var firstElement = shuffle(array)[0];
+		firstElementDifferent = firstElementDifferent || firstElement !== shuffledFirst;
+	}
+	t.true( firstElementDifferent, 'unseeded shuffle should produce different result eventually' );
+
+	function shuffleWithSeed(array, seed){
+		var tpl = Handlebars.compile('{{#shuffle this seed='+seed+'}}{{this}},{{/shuffle}}');
+		var result = tpl( array );
+		return result.substring( 0, result.length - 1 ).split(',');
+	}
+	array.sort();
+	var shuffledFirst = shuffleWithSeed(array, 1)[0];
+	firstElementDifferent = false;
+	for (var i=0; i<100; i++) {
+		array.sort();
+		var firstElement = shuffleWithSeed(array, 1)[0];
+		firstElementDifferent = firstElementDifferent || firstElement !== shuffledFirst;
+	}
+	t.false( firstElementDifferent, 'seeded shuffle should always produce the same result' );
 });
 
 test( 'reverse', function( t ){


### PR DESCRIPTION
I needed a way to reproducibly shuffle an array, so that I won't get different results each time the template is running (unless the underlying data is changed). This PR adds an optional seed argument to the shuffle function. If no seed is passed, the original functionality is retained.
